### PR TITLE
Some fixes on add interface function

### DIFF
--- a/os_dep/linux/ioctl_cfg80211.c
+++ b/os_dep/linux/ioctl_cfg80211.c
@@ -3986,6 +3986,11 @@ static int rtw_cfg80211_add_monitor_if(_adapter *padapter, char *name, struct ne
 	mon_wdev->netdev = mon_ndev;
 	mon_wdev->iftype = NL80211_IFTYPE_MONITOR;
 	mon_ndev->ieee80211_ptr = mon_wdev;
+	
+	SET_NETDEV_DEV(mon_ndev, wiphy_dev(pwdev_priv->rtw_wdev->wiphy));
+	
+	memcpy(mon_ndev->dev_addr, padapter->pnetdev->dev_addr, ETH_ALEN);
+	memcpy(mon_ndev->perm_addr, padapter->pnetdev->perm_addr, ETH_ALEN);
 
 	ret = register_netdevice(mon_ndev);
 	if (ret) {


### PR DESCRIPTION
This patch fixes the lack of device folder on added interface as seen on point 2 of [issue11](https://github.com/astsam/rtl8812au/issues/11#issuecomment-279298377) also it gives the same mac address to the new mon interface, instead of 00:00:00:00:00:00.

So airmon-ng will create the virtual device correctly but it doesn't work yet... Also when running airmon-ng stop wlan0mon it deletes the wlan0mon interface but can't bring back the inteface wlan0. And if you run rmmod 8812au or remove the device It causes kernel seg fault.

However if you create a mon interface ussing iw: `iw dev wlan0 interface add mon0 type monitor` and later you remove it `iw mon0 del` doesn't cause seg fault on kernel but mon0 interface doesn't still work...

A weird behaviour happened when I ran `airodoump-ng -c 1 wlan0` during a while and then I ran `aireplay-ng -9 mon0`, in that case mon0 found one AP and triyed to inject packets...

It could be a good approach to make this driver compatible with airmon-ng... but it needs more work.