### PR TITLE
Update osdep_service_linux.h to compile with kernel 4.3.11+

### DIFF
--- a/include/osdep_service_linux.h
+++ b/include/osdep_service_linux.h
@@ -46,6 +46,9 @@
 #endif
 	#include <linux/sem.h>
 	#include <linux/sched.h>
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 11, 0))
+	#include <linux/sched/signal.h>
+#endif
 	#include <linux/etherdevice.h>
 	#include <linux/wireless.h>
 	#include <net/iw_handler.h>


### PR DESCRIPTION
Currently the source code won't compile because a few headers have moved. This code line will just include the new location if the kernel version is higher than 4.3.11